### PR TITLE
Add async capability

### DIFF
--- a/citybikes/client.py
+++ b/citybikes/client.py
@@ -27,8 +27,9 @@ class Client(object):
     def async_request(self, url, **kwargs):
         kwargs['url'] = url
         with aiohttp.ClientSession(loop=self.loop, headers=self.headers) as session:
-            response = yield from session.request(**kwargs)
-        return response
+            encoded_response = yield from session.request(**kwargs)
+            json_response = yield from encoded_response.json()
+        return json_response
 
 
 class Network(Resource):

--- a/citybikes/client.py
+++ b/citybikes/client.py
@@ -17,7 +17,7 @@ class Client(object):
         self.headers = {
             'User-Agent': user_agent or self.USER_AGENT
         }
-        self.loop = loop or asyncio.get_event_loop()
+        self.loop = loop
         self.networks = Networks(self)
 
     def request(self, url, **kwargs):

--- a/citybikes/client.py
+++ b/citybikes/client.py
@@ -17,7 +17,7 @@ class Client(object):
         self.headers = {
             'User-Agent': user_agent or self.USER_AGENT
         }
-        self.loop = loop
+        self.loop = loop or asyncio.get_event_loop()
         self.networks = Networks(self)
 
     def request(self, url, **kwargs):
@@ -26,9 +26,8 @@ class Client(object):
     @asyncio.coroutine
     def async_request(self, url, **kwargs):
         kwargs['url'] = url
-        session = aiohttp.ClientSession(loop=self.loop, headers=self.headers)
-        response = yield from self.session.request(**kwargs)
-        session.release()
+        with aiohttp.ClientSession(loop=self.loop, headers=self.headers) as session:
+            response = yield from session.request(**kwargs)
         return response
 
 

--- a/citybikes/resource.py
+++ b/citybikes/resource.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import json
 import asyncio
 import aiohttp
 from six.moves.urllib.parse import urljoin
@@ -76,3 +77,8 @@ class AbstractResource(Resource):
 
     def request(self, *args, **kwargs):
         return self.parent.request(*args, **kwargs)
+
+
+class JSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        return o.data

--- a/citybikes/resource.py
+++ b/citybikes/resource.py
@@ -51,8 +51,13 @@ class Resource(MutableMapping):
         self.data[key] = value
 
     def request(self, _path=None, **kwargs):
-        self.client.loop.run_until_complete(self.async_request(_path,
-            **kwargs))
+        if not self.client.loop.is_running():
+            self.client.loop.run_until_complete(
+                self.async_request(_path, **kwargs))
+            self.client.loop.close()
+        else:
+            asyncio.run_coroutine_threadsafe(self.async_request(_path,
+                **kwargs), self.client.loop).result()
 
     @asyncio.coroutine
     def async_request(self, _path=None, **kwargs):

--- a/citybikes/resource.py
+++ b/citybikes/resource.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import json
 import asyncio
 import aiohttp
 from six.moves.urllib.parse import urljoin
@@ -57,9 +56,8 @@ class Resource(MutableMapping):
     @asyncio.coroutine
     def async_request(self, _path=None, **kwargs):
         kwargs['method'] = 'GET'
-        response = yield from self.client.async_request(
+        data = yield from self.client.async_request(
             urljoin(self.url, _path), **kwargs)
-        data = yield from response.json()
         if self.resource_wrap:
             data = data[self.resource_wrap]
         self._data.update(data)
@@ -78,8 +76,3 @@ class AbstractResource(Resource):
 
     def request(self, *args, **kwargs):
         return self.parent.request(*args, **kwargs)
-
-
-class JSONEncoder(json.JSONEncoder):
-    def default(self, o):
-        return o.data

--- a/citybikes/resource.py
+++ b/citybikes/resource.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import json
+import asyncio
+import aiohttp
 from six.moves.urllib.parse import urljoin
 from collections import MutableMapping
 
@@ -49,8 +51,13 @@ class Resource(MutableMapping):
         self.data[key] = value
 
     def request(self, _path=None, **kwargs):
+        asyncio.wait(self.async_request(_path, **kwargs))
+
+    @asyncio.coroutine
+    def async_request(self, _path=None, **kwargs):
         kwargs['method'] = 'GET'
-        data = self.client.request(urljoin(self.url, _path), **kwargs).json()
+        data = yield from self.client.async_request(urljoin(self.url, _path),
+                                                    **kwargs).json()
         if self.resource_wrap:
             data = data[self.resource_wrap]
         self._data.update(data)

--- a/citybikes/resource.py
+++ b/citybikes/resource.py
@@ -51,13 +51,15 @@ class Resource(MutableMapping):
         self.data[key] = value
 
     def request(self, _path=None, **kwargs):
-        asyncio.wait(self.async_request(_path, **kwargs))
+        self.client.loop.run_until_complete(self.async_request(_path,
+            **kwargs))
 
     @asyncio.coroutine
     def async_request(self, _path=None, **kwargs):
         kwargs['method'] = 'GET'
-        data = yield from self.client.async_request(urljoin(self.url, _path),
-                                                    **kwargs).json()
+        response = yield from self.client.async_request(
+            urljoin(self.url, _path), **kwargs)
+        data = yield from response.json()
         if self.resource_wrap:
             data = data[self.resource_wrap]
         self._data.update(data)
@@ -76,6 +78,7 @@ class AbstractResource(Resource):
 
     def request(self, *args, **kwargs):
         return self.parent.request(*args, **kwargs)
+
 
 class JSONEncoder(json.JSONEncoder):
     def default(self, o):


### PR DESCRIPTION
Hi!

I'm integrating the API in [Home Assistant](https://home-assistant.io), and instead of accessing the web API directly, I was requested to use a Python library (the rationale behind it is to share as much code as possible back with the community).

However, Home Assistant is running (mostly) asynchronous code, and I wanted to make sure the new code I'm adding follows that philosophy. Therefore, I made changes to this library, making it async. This, however, breaks the backwards compatibility with Python 2.7.

Would you like to merge this new feature somehow?